### PR TITLE
feat: adds support for generating report file names and file prefix

### DIFF
--- a/dev/payload.config.ts
+++ b/dev/payload.config.ts
@@ -2,11 +2,11 @@ import { mongooseAdapter } from '@payloadcms/db-mongodb'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import path from 'path'
 import { buildConfig } from 'payload'
-import { pageSpeedPlugin } from 'payload-plugin-pagespeed'
 import sharp from 'sharp'
 import { fileURLToPath } from 'url'
 
 import { testEmailAdapter } from './helpers/testEmailAdapter.js'
+import { plugins } from './plugins.js'
 /* import { getMemoryDB } from './helpers/getMemoryDB.js' */
 import { seed } from './seed.js'
 
@@ -51,12 +51,7 @@ const buildConfigWithMemoryDB = async () => {
     onInit: async (payload) => {
       await seed(payload)
     },
-    plugins: [
-      pageSpeedPlugin({
-        apiKey: process.env.PAGESPEED_API_KEY || 'fake-api-key',
-        debug: true,
-      }),
-    ],
+    plugins,
     secret: process.env.PAYLOAD_SECRET || 'test-secret_key',
     sharp,
     typescript: {

--- a/dev/plugins.ts
+++ b/dev/plugins.ts
@@ -1,0 +1,12 @@
+import type { Plugin } from 'payload'
+import type { PageSpeedPluginConfig } from 'payload-plugin-pagespeed'
+
+import { pageSpeedPlugin } from 'payload-plugin-pagespeed'
+
+export const pageSpeedPluginConfig: PageSpeedPluginConfig = {
+  apiKey: process.env.PAGESPEED_API_KEY || 'fake-api-key',
+  debug: true,
+  generateFileName: () => 'test-report.json',
+}
+
+export const plugins: Plugin[] = [pageSpeedPlugin(pageSpeedPluginConfig)]

--- a/dev/test/integration/fetchPluginEndpoint.ts
+++ b/dev/test/integration/fetchPluginEndpoint.ts
@@ -6,6 +6,7 @@ import { createPayloadRequest } from 'payload'
 import { fetchPageSpeedReport } from '../../../src/endpoints/pagespeed/fetchPageSpeedReport.js'
 import { pageSpeedEndpointHandler } from '../../../src/endpoints/pagespeed/handler.js'
 import { insightsSlug, reportsSlug } from '../../helpers/defaults.js'
+import { pageSpeedPluginConfig } from '../../plugins.js'
 import { getMockFetchReportFn } from '../mock/fetchReport.js'
 import { login } from './login.js'
 
@@ -52,7 +53,7 @@ export async function fetchPluginEndpoint({
       ? getMockFetchReportFn({ filePath: './mock-report-desktop.json' })
       : fetchPageSpeedReport,
     insightsSlug,
-    pluginConfig: { apiKey },
+    pluginConfig: { ...pageSpeedPluginConfig, apiKey },
     reportsSlug,
     req,
   })

--- a/dev/test/integration/int.spec.ts
+++ b/dev/test/integration/int.spec.ts
@@ -4,6 +4,8 @@ import config from '@payload-config'
 import { getPayload } from 'payload'
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
+import type { PagespeedReport } from '../../payload-types.js'
+
 import { PageSpeedStrategies } from '../../../src/utilities/pageSpeedStrategies.js'
 import { insightsSlug, reportsSlug } from '../../helpers/defaults.js'
 import { seed } from '../../seed.js'
@@ -85,11 +87,7 @@ describe('payload-plugin-pagespeed', () => {
         },
         depth: 0,
       })
-
-      expect(insightsDoc).toBeTruthy()
-
       const response = await fetchPluginEndpoint({ docId: insightsDoc.id, payload })
-
       expect(response.status).toBe(200)
 
       const updatedDoc = await payload.findByID({
@@ -169,6 +167,29 @@ describe('payload-plugin-pagespeed', () => {
       })
 
       expect(insightsDoc.title).toEqual(`${url} - ${strategy.label}`)
+    })
+
+    test('should generate a file name when function is present in plugin config', async () => {
+      const insightsDoc = await payload.create({
+        collection: insightsSlug,
+        data: {
+          url: 'http://localhost:3000',
+        },
+        depth: 0,
+      })
+      const response = await fetchPluginEndpoint({ docId: insightsDoc.id, payload })
+      expect(response.status).toBe(200)
+      const updatedDoc = await payload.findByID({
+        id: insightsDoc.id,
+        collection: insightsSlug,
+        depth: 1,
+      })
+      const report = updatedDoc.report as PagespeedReport
+      expect(report.filename).toBe('test-report.json')
+    })
+
+    test.skip('should generate a file prefix when function is present in plugin config', async () => {
+      // TODO: Requires storage adapter
     })
   })
 })

--- a/src/collections/Reports/getReportsCollection.ts
+++ b/src/collections/Reports/getReportsCollection.ts
@@ -2,6 +2,8 @@ import type { CollectionConfig } from 'payload'
 
 import type { PageSpeedPluginConfig } from '../../types/index.js'
 
+import { getGenerateFilePrefixHook } from './hooks/getGenerateFilePrefixHook.js'
+
 type Args = {
   pluginConfig: PageSpeedPluginConfig
 }
@@ -9,12 +11,17 @@ type Args = {
 export function getReportsCollection({ pluginConfig }: Args) {
   const slug = 'pagespeed-reports'
 
+  const generateFilePrefixHook = getGenerateFilePrefixHook({ pluginConfig })
+
   const collection: CollectionConfig = {
     slug,
     admin: {
       hidden: !pluginConfig.debug,
     },
     fields: [],
+    hooks: {
+      beforeOperation: [generateFilePrefixHook],
+    },
     timestamps: false,
     upload: {
       modifyResponseHeaders: ({ headers }) => {

--- a/src/collections/Reports/hooks/getGenerateFilePrefixHook.ts
+++ b/src/collections/Reports/hooks/getGenerateFilePrefixHook.ts
@@ -1,0 +1,25 @@
+import type { CollectionBeforeOperationHook } from 'payload'
+
+import type { PageSpeedPluginConfig } from '../../../types/index.js'
+
+type Args = {
+  pluginConfig: PageSpeedPluginConfig
+}
+
+export function getGenerateFilePrefixHook({
+  pluginConfig: { generateFilePrefix },
+}: Args): CollectionBeforeOperationHook {
+  return ({ collection, operation, req }) => {
+    if (
+      req.file &&
+      req.data &&
+      (operation === 'create' || operation === 'update') &&
+      typeof generateFilePrefix !== 'undefined'
+    ) {
+      req.data.prefix = generateFilePrefix({
+        collection,
+        req,
+      })
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,5 @@ export const pageSpeedPlugin =
 
     return config
   }
+
+export { PageSpeedPluginConfig }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,24 @@
-import type { CollectionConfig, CollectionSlug } from 'payload'
+import type {
+  CollectionConfig,
+  CollectionSlug,
+  PayloadRequest,
+  SanitizedCollectionConfig,
+} from 'payload'
 
 export type CollectionOverride = (collection: CollectionConfig) => CollectionConfig
+
+export type GenerateFileNameFnArgs = {
+  analysisTimestamp: string
+  extension?: string
+  requestedUrl: string
+}
+export type GenerateFileNameFn = (args: GenerateFileNameFnArgs) => string
+
+export type GenerateFilePrefixFnArgs = {
+  collection: SanitizedCollectionConfig
+  req: PayloadRequest
+}
+export type GenerateFilePrefixFn = (args: GenerateFilePrefixFnArgs) => string
 
 export type PageSpeedPluginConfig = {
   apiKey: string
@@ -10,6 +28,8 @@ export type PageSpeedPluginConfig = {
   collections?: Partial<Record<CollectionSlug, true>>
   debug?: boolean
   disabled?: boolean
+  generateFileName?: GenerateFileNameFn
+  generateFilePrefix?: GenerateFilePrefixFn
   overrideInsightsCollection?: CollectionOverride
   overrideReportsCollection?: CollectionOverride
 }

--- a/src/utilities/defaultGenerateFileName.ts
+++ b/src/utilities/defaultGenerateFileName.ts
@@ -1,0 +1,21 @@
+import type { GenerateFileNameFnArgs } from '../types/index.js'
+
+export function defaultGenerateFileName({
+  analysisTimestamp,
+  extension = '.json',
+  requestedUrl,
+}: GenerateFileNameFnArgs) {
+  // Remove protocol
+  const urlWithoutProtocol = requestedUrl.replace(/^https?:\/\//, '')
+
+  // Remove leading slash
+  const urlCleaned = urlWithoutProtocol.replace(/^\/+/, '')
+
+  // Replace unsafe filename characters with '_'
+  const safeUrl = urlCleaned.replace(/[<>:"/\\|?*\s]/g, '-')
+
+  // Replace colon in timestamp if present (common in ISO strings)
+  const safeTimestamp = analysisTimestamp.replace(/:/g, '-')
+
+  return `${safeTimestamp}_${safeUrl}${extension}`
+}


### PR DESCRIPTION
### What?
This PR adds support for passing custom file name and prefix functions to the underlying pagespeed-reports upload  collection.

### Why?
To allow end users to customize the default behavior via plugin config.

### How?
By threading generateFileName and generateFilePrefix functions from plugin config to their respective handlers.