### PR TITLE
chore: bump release to v0.1.0 [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payload-plugin-pagespeed",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "A tiny PageSpeed Insights API plugin for PayloadCMS",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
This PR bumps the package version to 0.1.0.