### PR TITLE
feat: add url field with validation

### DIFF
--- a/src/collections/Insights/getInsightsCollection.ts
+++ b/src/collections/Insights/getInsightsCollection.ts
@@ -3,6 +3,7 @@ import type { CollectionConfig, Endpoint } from 'payload'
 import type { PageSpeedPluginConfig } from '../../types/index.js'
 
 import { getPageSpeedEndpoint } from '../../endpoints/pagespeed/index.js'
+import { urlField } from '../../fields/url/index.js'
 import { PageSpeedCategories } from '../../utilities/pageSpeedCategories.js'
 import { PageSpeedStrategies } from '../../utilities/pageSpeedStrategies.js'
 import { getDeleteReportHook } from './hooks/getDeleteReportHook.js'
@@ -79,14 +80,12 @@ export function getInsightsCollection({ pluginConfig, reportsSlug }: Args): Coll
           },
           {
             fields: [
-              {
-                name: 'url',
-                type: 'text',
+              urlField({
                 admin: {
                   description: 'The URL to fetch and analyze.',
                 },
                 required: true,
-              },
+              }),
               {
                 name: 'categories',
                 type: 'select',

--- a/src/fields/url/formatURL.ts
+++ b/src/fields/url/formatURL.ts
@@ -1,0 +1,20 @@
+import type { FieldHook } from 'payload'
+
+export const formatURL = (val: string): string => {
+  try {
+    new URL(val)
+    return val
+  } catch {
+    if (!val.startsWith('http://') || !val.startsWith('https://')) {
+      return `https://${val}`
+    }
+    return val
+  }
+}
+
+export const formatURLHook: FieldHook = ({ operation, value }) => {
+  if (typeof value === 'string' && operation === 'create') {
+    return formatURL(value)
+  }
+  return value
+}

--- a/src/fields/url/index.ts
+++ b/src/fields/url/index.ts
@@ -1,0 +1,22 @@
+import type { TextField } from 'payload'
+
+import { formatURLHook } from './formatURL.js'
+import { validate } from './validate.js'
+
+type URLField = (overrides?: Partial<TextField>) => TextField
+
+export const urlField: URLField = (overrides = {}) => {
+  const { name = 'url', type: _, hasMany: __, ...rest } = overrides
+
+  const field = {
+    name,
+    type: 'text',
+    hooks: {
+      beforeValidate: [formatURLHook],
+    },
+    validate,
+    ...rest,
+  } as TextField
+
+  return field
+}

--- a/src/fields/url/validate.ts
+++ b/src/fields/url/validate.ts
@@ -1,0 +1,19 @@
+import type { TextFieldSingleValidation } from 'payload'
+
+import { text } from 'payload/shared'
+
+const pattern = /^(?:https?:\/\/)?(?:[\w-]+\.)+[a-z]{2,}(?:\/\S*)?$/i
+
+export const validate: TextFieldSingleValidation = (value, options) => {
+  const { req } = options
+
+  if (!value) {
+    return req.t('validation:required')
+  }
+
+  if (!pattern.test(value)) {
+    return req.t('validation:invalidInput')
+  }
+
+  return text(value, options)
+}


### PR DESCRIPTION
### What
This PR introduces a new custom url field to use in the Insights collection. 

### Why
To ensure url's saved to docs are valid for use with the PageSpeed Insights API.

### How
By adding a new url field function which returns a text field. This text field has a custom `validate` function and a `beforeValidate` function to ensure validity without being restrictive for end-users.